### PR TITLE
Remove the support phone from the pages

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -37,6 +37,7 @@
 
 <div class="row text-center mt-5 mb-5">
   <div class="col">
-    <small class="text-muted"> Caso você esteja esteja com dificuldades para acessar o sistema<br>Entre em contato diretamente com nossa central através do telefone </small><a class="small" href="tel:04734815165">(47) 3481-5165</a>
+    <small class="text-muted">Para mais informações sobre eventos de vacinação da cidade, acesse:<br>
+    <a href="https://www.joinville.sc.gov.br/?post_type=evento&tag-tipo-evento=conscientizacao&s=">https://www.joinville.sc.gov.br/evento/conscientizacao/</a></small>
   </div>
 </div>

--- a/app/views/patients/age_not_allowed.html.erb
+++ b/app/views/patients/age_not_allowed.html.erb
@@ -1,6 +1,6 @@
 <div class="row text-center">
   <div class="col">
-    <p class="h3 mb-12">Caro cidadão:</p>
+    <p class="h3 mb-12">Prezado cidadão:</p>
   </div>
 </div>
 
@@ -12,7 +12,8 @@
 
 <div class="row text-center">
   <div class="col">
-    <p class="h8 mb-12">Para mais informações, ligue ou mande uma mensagem pelo WhatsApp para <strong>3481-5165</strong></p>
+    <p class="h8 mb-12">Para mais informações sobre eventos de vacinação da cidade, acesse:</p>
+    <p class="h8 mb-12"><a href="https://www.joinville.sc.gov.br/?post_type=evento&tag-tipo-evento=conscientizacao&s=">https://www.joinville.sc.gov.br/evento/conscientizacao/</a></p>
   </div>
 </div>
 

--- a/app/views/patients/blocked.html.erb
+++ b/app/views/patients/blocked.html.erb
@@ -12,14 +12,15 @@
 
 <div class="row text-center">
   <div class="col">
-    <p class="h8 mb-12">Para destravar a conta, ligue para <strong>3481-5165</strong></p>
+    <p class="h8 mb-12">Para destravar a conta, ligue para <strong>3481-5151</strong></p>
   </div>
 </div>
 <br>
 
 <div class="row text-center">
   <div class="col">
-    <p class="h8 mb-12">Para mais informações, acesse o site oficial em <a href="https://www.joinville.sc.gov.br/coronavirus/">https://www.joinville.sc.gov.br/coronavirus/</a></p>
+    <p class="h8 mb-12">Para mais informações sobre eventos de vacinação da cidade, acesse:</p>
+    <p class="h8 mb-12"><a href="https://www.joinville.sc.gov.br/?post_type=evento&tag-tipo-evento=conscientizacao&s=">https://www.joinville.sc.gov.br/evento/conscientizacao/</a></p>
   </div>
 </div>
 <br>

--- a/app/views/patients/successfull_schedule.html.erb
+++ b/app/views/patients/successfull_schedule.html.erb
@@ -30,8 +30,6 @@
       <br>
       Caso haja alteração por parte da unidade, será realizado contato pelo telefone informado no cadastro.
       <br>
-      Dúvidas a respeito do agendamento, ligar no número <strong>3481-5151</strong>.
-      <br>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Hello guys,

This pull request proposes substitute the support phone from some pages for a link to a information page about the vaccinations events at city. 
