### PR TITLE
Fixing partially the conflicting range of the time slots

### DIFF
--- a/app/models/concerns/time_slot.rb
+++ b/app/models/concerns/time_slot.rb
@@ -37,8 +37,9 @@ module TimeSlot
     start_slot = time_slot[:slot_start]
     end_slot = time_slot[:slot_end]
 
-    start_slot.between?(appointment.start, appointment.end) ||
-      end_slot.between?(appointment.start, appointment.end)
+    start_slot.between?(appointment.start, appointment.end-1) ||
+      end_slot.between?(appointment.start+1, appointment.end)
+      # TODO fix when appointment begins and ends between start_slot and end_slot
   end
 
   def time_slots(time_range)


### PR DESCRIPTION
Hello :owl: 

**This is a small but important improvement :exclamation:**

Here I make a little adjust in the range of `between?` method, excluding the extremes of the range, because before was including the early and after appointment in conflicting time_slot of an already appointment.

**TODO**: An another condition which the new `time_slot` shouldn't has an already appointment inside it.

P.S.: Sorry @GabrielaMafra for making some mess in your code :sweat_smile: 