### PR TITLE
Fix patient not found error

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,9 +21,13 @@ class HomeController < ApplicationController
   def unblock
     patient = Patient.find_by(cpf: unblock_params[:cpf])
 
-    patient.unblock!
+    if patient
+      patient.unblock!
 
-    render html: "<h1>#{patient.name.titleize} desbloqueado!</h1>".html_safe
+      render html: "<h1>#{patient.name.titleize} desbloqueado!</h1>".html_safe
+    else
+      render html: '<h1>Paciente não encontrado</h1>'.html_safe
+    end
   end
 
   private

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe HomeController, type: :controller do
+  let(:patient) { Patient.last }
+
+  describe 'GET #unblock' do
+    context 'when patient exists' do
+      it 'unblocks the patient' do
+        get :unblock, params: { cpf: patient.cpf }
+
+        expect(response.body).to eq("<h1>#{patient.name} desbloqueado!</h1>")
+      end
+    end
+
+    context 'when patient does not exists' do
+      it 'renders patient not found message' do
+        get :unblock, params: { cpf: 'asad' }
+
+        expect(response.body).to eq('<h1>Paciente não encontrado</h1>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello!

Here we do a small fix for an error that was polluting sentry:
https://sentry.io/organizations/magrathealabs/issues/1603980436/?project=5191494&query=is%3Aunresolved

We just set a default message for the unblock route when a patient is not found (most likelly when a cpf was typed incorrectly)

Also, initial home controller testing :taco: 