### PR TITLE
Adjust available time slot visualization for patients

### DIFF
--- a/app/controllers/ubs_controller.rb
+++ b/app/controllers/ubs_controller.rb
@@ -77,7 +77,7 @@ class UbsController < UserSessionController
 
   def activate_all_future_appointments
     appointments = @ubs.appointments.where(
-      'start >= ? AND active = ?', Time.zone.now, false
+      'start >= ? AND active = ?', Time.zone.now - @ubs.slot_interval_minutes * 60, false
     )
 
     appointments.update_all(active: true)
@@ -95,7 +95,7 @@ class UbsController < UserSessionController
 
   def future_appointments
     @future_appointments = @ubs.appointments.where(
-      'start >= ?', Time.zone.now
+      'start >= ?', Time.zone.now - @ubs.slot_interval_minutes * 60
     )
   end
 

--- a/app/views/time_slot/index.html.erb
+++ b/app/views/time_slot/index.html.erb
@@ -99,9 +99,7 @@
                                   <% slots.each do |slot| %>
                                     <div class="row">
                                       <div class="col align-middle">
-                                        Horário <br /> <%= ApplicationHelper.humanize_time(slot[:slot_start]) %>
-                                        - <%= ApplicationHelper.humanize_time(slot[:slot_end]) %>
-                                      </div>
+                                        Horário <br /> <%= ApplicationHelper.humanize_time(slot[:slot_start]) %>                                      </div>
                                       <div class="col text-right">
                                         <%= button_to @appointment.present? ? 'Substituir' : 'Agendar', schedule_time_slot_path(start_time: slot[:slot_start], ubs_id: ubs.id), class: "btn btn-success" %>
                                       </div>

--- a/app/views/ubs/active_hours.html.erb
+++ b/app/views/ubs/active_hours.html.erb
@@ -1,4 +1,4 @@
-<h1>Alterar horário de funcionamento de <%= @ubs.name %></h1>
+<h1>Alterar horário de funcionamento</h1>
 
 <% if @ubs.errors.present? %>
   <div id="error_explanation">
@@ -45,8 +45,8 @@
 
   </div>
   <div class="d-flex mt-5 justify-content-center">
-  <% if @appointments.present? %>
-    <div class="alert alert-warning">Não é possível modificar horário de funcionamento enquanto houverem agendamentos.</div>
+  <% if @ubs.active %>
+    <div class="alert alert-warning">Não é possível modificar horário de funcionamento enquanto a unidade estiver ativa.</div>
   <% else %>
     <%= f.submit "Atualizar", class: 'btn btn-primary' %>
   <% end %>

--- a/app/views/ubs/index.html.erb
+++ b/app/views/ubs/index.html.erb
@@ -1,14 +1,16 @@
+<h1><%= @ubs.name %></h1>
+
 <% if @ubs.active %>
   <div class="d-flex justify-content-between align-items-center alert alert-success" role="alert">
-    UBS ativada. Aceitando agendamentos
+    Unidade ativada: Aceitando agendamentos.
     <a class="btn btn-danger" href=<%= "/ubs/#{@ubs.id}/deactivate_ubs" %>
-    onclick="return confirm('Você tem certeza?')">Desativar UBS</a>
+    onclick="return confirm('Você tem certeza?')">Desativar Unidade</a>
   </div>
 <% else %>
   <div class="d-flex justify-content-between align-items-center alert alert-danger" role="alert">
-    UBS desativada. Não aceitando agendamentos
+    Unidade desativada: Não aceitando agendamentos.
     <a class="btn btn-success" href=<%= "/ubs/#{@ubs.id}/activate_ubs" %>
-    onclick="return confirm('Você tem certeza?')">Ativar UBS</a>
+    onclick="return confirm('Você tem certeza?')">Ativar Unidade</a>
   </div>
 <% end %>
 
@@ -20,18 +22,18 @@
     <table class="table table-hover">
       <thead>
         <tr>
-          <th scope="col">Horário Agendado</th>
+          <th scope="col">Data e Hora</th>
           <th scope="col">Paciente</th>
           <th scope="col">Telefone Principal</th>
           <th scope="col">Telefone Secundário</th>
-          <th scope="col"> </th>
+          <th scope="col">Ação Sobre o Agendamento</th>
         </tr>
       </thead>
       <tbody>
     <% @appointments.each do |appointment| %>
       <% if appointment.active %>
         <tr>
-          <th scope="row"><%= appointment.start.strftime("%H:%M - %d/%m/%Y") %></th>
+          <th scope="row"><%= appointment.start.strftime("%d/%m/%Y -- %H:%M") %></th>
           <td><a href=<%= "/patients/#{appointment.patient.id}" %>><%= appointment.patient.name %></a></td>
           <td><%= appointment.patient.phone %></td>
           <td><%= appointment.patient.other_phone %></td>

--- a/app/views/ubs/slot_duration.html.erb
+++ b/app/views/ubs/slot_duration.html.erb
@@ -11,7 +11,7 @@
 <%= form_for @ubs, url: ubs_change_slot_duration_path do |f| %>
   <div class="field">
     <%= f.label :slot_interval_minutes, 'Duração de cada atendimento (em minutos):' %><br />
-    <% if @appointments.present? %>
+    <% if @ubs.active %>
       <%= f.number_field :slot_interval_minutes, disabled: 'disabled' %>
     <% else %>
       <div class="form-group col-md-4">
@@ -21,8 +21,8 @@
   </div>
 
   <div class="d-flex mt-3">
-    <% if @appointments.present? %>
-      <div class="alert alert-warning">Não é possível modificar duração da consulta enquanto houverem agendamentos.</div>
+    <% if @ubs.active %>
+      <div class="alert alert-warning">Não é possível modificar duração do atendimento enquanto a unidade estiver ativa.</div>
     <% else %>
       <%= f.submit "Atualizar", class: 'btn btn-primary' %>
     <% end %>


### PR DESCRIPTION
Hi guys, here is some more suggestions of UI improvements:

**1. Show only start time of available appointments for Patients:**
The reason of this change is because the patients can think that they could arrive at UBS between start and end appointment time, but this interval is for total time of appointment and they should arrive on start time of appointment. (`app/views/time_slot/index`)
![start_time_appoint](https://user-images.githubusercontent.com/19494561/79983919-d30fdf80-847e-11ea-9fbd-89a7f0201e11.png)

 \
**2. Show the UBS name in main page of UBS / Users:**
This change is only for commit that user is in correct UBS on login. (`app/view/ubs/index`)
![ubs_name_main_view](https://user-images.githubusercontent.com/19494561/79988869-8e3b7700-8485-11ea-8afb-3b2f543b6fc1.png)

 \
**3. Show time after the date in future appointments for User:**
Showing the date before the time, making the appointment list more intuitive for the user's appointment search. (`app/view/ubs/index`)
![new_list_appointments](https://user-images.githubusercontent.com/19494561/79990727-c479f600-8487-11ea-951d-acb3e8aa2b95.png)

 \
**4. Allow update active hours and slot interval deactivating the UBS:**
This change is already proposed in another PR, but for some reason the Github wasn't allowing this changes merged...
The users already changes the active hours and slot interval at the UBS only after deactivating the unit (our recommendation for avoid some patient made an appointment between this time) and cancel all future appointments, here the users don't need the second step anymore.
![changing_ubs_parameters](https://user-images.githubusercontent.com/19494561/79993576-47508000-848b-11ea-860c-a01558cbd689.gif)
